### PR TITLE
I changed SRID for INP file from 4326 to UTM coordinates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   python:
-    image: wasac/postgis2epanet:v2.0.0
+    image: wasac/postgis2epanet:v2.0.1
     # build: .
     environment:
      - db_user=postgres

--- a/epanet/coordinates.py
+++ b/epanet/coordinates.py
@@ -41,8 +41,8 @@ class Coordinates(LayerBase):
         def add_coordinate(self, f):
             f.writelines(" {0}\t{1}\t{2}\n"
                          .format("{0}\t".format(self.id).expandtabs(20),
-                                 "{0}\t".format(self.lon).expandtabs(16),
-                                 "{0}\t".format(self.lat).expandtabs(16)))
+                                 "{0}\t".format(self.lon_utm).expandtabs(16),
+                                 "{0}\t".format(self.lat_utm).expandtabs(16)))
 
     def __init__(self, wss_id):
         super().__init__("junctions", wss_id)


### PR DESCRIPTION
Because it cannot enable auto length calculation in EPANET, I changed SRID for INP files from EPSG:4326 to UTM coordinates. However, SRID for Shapefiles is still longitude & latitude.